### PR TITLE
Issue/#8

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,14 +7,13 @@ on:
       - 'main'
 
 jobs: 
-  build: 
+  setup: 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 11
-    - uses: actions/setup-java@v3
-    with :
-      java-version: '11'
-      distribution: 'temurin'
-      cache: maven
-    - run: mvn --batch-mode --update-snapshots verify
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with :
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+      - run: mvn --batch-mode --update-snapshots verify


### PR DESCRIPTION
Closes #8. Implements Java build with Java version 17, distribution temurin, and caches project dependencies. 